### PR TITLE
fix(systemd): resolve claude binary and lift W^X trap

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -89,6 +89,22 @@ Inspect the full error dict in the traceback. Common causes:
 - **Model name invalid**. Check `llm_model` in `config.yaml`.
 - **Token revoked**. Regenerate with `claude setup-token`.
 
+### `FileNotFoundError: 'claude'` under systemd
+
+systemd user units run with a minimal default PATH that excludes
+`~/.local/bin`, where the official Claude Code installer drops the binary.
+The shipped `hyacine-run.service` template pins `Environment=PATH=` to
+include it. If you're on an old copy, either redeploy the unit or set
+`HYACINE_CLAUDE_BIN=/absolute/path/to/claude` in `./.env`.
+
+### Subprocess exits with empty stdout/stderr (SIGTRAP)
+
+`claude` 2.1.x ships as a single ELF binary with embedded JIT.
+`MemoryDenyWriteExecute=true` in the systemd unit traps the runtime when it
+tries to mark JIT pages writable+executable, killing the process with
+SIGTRAP and no diagnostics. The shipped template leaves MDWE off — if you
+hand-rolled your unit, comment that line out.
+
 ### Subprocess billed to the wrong account
 
 `ANTHROPIC_API_KEY` or `ANTHROPIC_AUTH_TOKEN` leaked into the unit

--- a/src/hyacine/llm/claude_code.py
+++ b/src/hyacine/llm/claude_code.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -29,6 +30,35 @@ def build_env(base_env: dict[str, str]) -> dict[str, str]:
     env.pop("ANTHROPIC_API_KEY", None)
     env.pop("ANTHROPIC_AUTH_TOKEN", None)
     return env
+
+
+def resolve_claude_bin(env: dict[str, str] | None = None) -> str:
+    """Locate the `claude` CLI as an absolute path.
+
+    Order: explicit `HYACINE_CLAUDE_BIN` env var, then `shutil.which` against an
+    augmented PATH that includes `~/.local/bin` (npm/uv default install dir
+    that systemd user units omit by default).
+    """
+    src = env if env is not None else os.environ
+    override = src.get("HYACINE_CLAUDE_BIN")
+    if override:
+        if not (os.path.isfile(override) and os.access(override, os.X_OK)):
+            raise ClaudeCodeError(
+                f"HYACINE_CLAUDE_BIN={override!r} is not an executable file."
+            )
+        return override
+
+    extra = os.path.expanduser("~/.local/bin")
+    path = src.get("PATH", os.defpath)
+    if extra not in path.split(os.pathsep):
+        path = f"{extra}{os.pathsep}{path}"
+    found = shutil.which("claude", path=path)
+    if not found:
+        raise ClaudeCodeError(
+            "claude CLI not found on PATH. Install Claude Code or set "
+            f"HYACINE_CLAUDE_BIN. Searched PATH={path!r}."
+        )
+    return found
 
 
 def build_argv(
@@ -84,6 +114,7 @@ def summarize(
         permission_mode=permission_mode,
     )
     env = build_env(os.environ.copy())
+    argv[0] = resolve_claude_bin(env)
 
     try:
         completed = subprocess.run(
@@ -146,4 +177,10 @@ def summarize(
     return str(result_event["result"])
 
 
-__all__ = ["summarize", "build_env", "build_argv", "ClaudeCodeError"]
+__all__ = [
+    "summarize",
+    "build_env",
+    "build_argv",
+    "resolve_claude_bin",
+    "ClaudeCodeError",
+]

--- a/src/hyacine/ops/systemd/hyacine-run.service
+++ b/src/hyacine/ops/systemd/hyacine-run.service
@@ -12,6 +12,11 @@ Wants=network-online.target
 Type=oneshot
 WorkingDirectory=%h/hyacine
 EnvironmentFile=%h/hyacine/.env
+# systemd's default user PATH omits ~/.local/bin, where the official Claude
+# Code installer drops the `claude` binary. Pin PATH so the subprocess in
+# hyacine.llm.claude_code can resolve it. (HYACINE_CLAUDE_BIN in .env wins
+# over PATH if the operator wants to point at a non-default location.)
+Environment=PATH=%h/.local/bin:/usr/local/bin:/usr/bin:/bin
 UnsetEnvironment=ANTHROPIC_API_KEY ANTHROPIC_AUTH_TOKEN
 # No Restart= on oneshot — the timer's Persistent=true handles missed runs.
 ExecStart=%h/hyacine/.venv/bin/python -m hyacine.pipeline.run
@@ -31,5 +36,9 @@ ProtectControlGroups=true
 RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
 RestrictNamespaces=true
 LockPersonality=true
-MemoryDenyWriteExecute=true
+# MemoryDenyWriteExecute disabled: claude 2.1.x ships as a single ELF binary
+# with embedded JIT. W^X enforcement traps the JIT and the subprocess dies
+# with SIGTRAP (empty stdout/stderr, no useful diagnostics). Re-enable only
+# if upstream ever switches to an AOT runtime.
+# MemoryDenyWriteExecute=true
 SystemCallArchitectures=native

--- a/tests/test_claude_code_wrapper.py
+++ b/tests/test_claude_code_wrapper.py
@@ -11,6 +11,7 @@ from hyacine.llm.claude_code import (
     ClaudeCodeError,
     build_argv,
     build_env,
+    resolve_claude_bin,
     summarize,
 )
 
@@ -130,6 +131,61 @@ class TestBuildArgv:
         assert argv[idx + 1] == "haiku"
         idx_turns = argv.index("--max-turns")
         assert argv[idx_turns + 1] == "5"
+
+
+# ---------------------------------------------------------------------------
+# resolve_claude_bin
+# ---------------------------------------------------------------------------
+
+class TestResolveClaudeBin:
+    def _make_fake_claude(self, dir_: Path) -> Path:
+        bin_path = dir_ / "claude"
+        bin_path.write_text("#!/bin/sh\nexit 0\n")
+        bin_path.chmod(0o755)
+        return bin_path
+
+    def test_explicit_override_wins(self, tmp_path: Path) -> None:
+        bin_path = self._make_fake_claude(tmp_path)
+        env = {"HYACINE_CLAUDE_BIN": str(bin_path), "PATH": "/nope"}
+        assert resolve_claude_bin(env) == str(bin_path)
+
+    def test_override_not_executable_raises(self, tmp_path: Path) -> None:
+        bin_path = tmp_path / "claude"
+        bin_path.write_text("not executable")
+        env = {"HYACINE_CLAUDE_BIN": str(bin_path), "PATH": "/nope"}
+        with pytest.raises(ClaudeCodeError, match="not an executable"):
+            resolve_claude_bin(env)
+
+    def test_falls_back_to_path(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Point HOME at an empty dir so the ~/.local/bin augmentation can't
+        # accidentally find the developer's real claude install.
+        empty_home = tmp_path / "home"
+        empty_home.mkdir()
+        monkeypatch.setenv("HOME", str(empty_home))
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        bin_path = self._make_fake_claude(bin_dir)
+        env = {"PATH": str(bin_dir)}
+        assert resolve_claude_bin(env) == str(bin_path)
+
+    def test_local_bin_augmented(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Simulate ~/.local/bin holding the binary while PATH excludes it —
+        # this is the exact systemd default-PATH situation we are guarding against.
+        fake_home = tmp_path / "home"
+        local_bin = fake_home / ".local" / "bin"
+        local_bin.mkdir(parents=True)
+        bin_path = self._make_fake_claude(local_bin)
+        monkeypatch.setenv("HOME", str(fake_home))
+        env = {"PATH": "/usr/bin:/bin"}
+        assert resolve_claude_bin(env) == str(bin_path)
+
+    def test_missing_raises(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        monkeypatch.setenv("HOME", str(empty))
+        env = {"PATH": str(empty)}
+        with pytest.raises(ClaudeCodeError, match="not found"):
+            resolve_claude_bin(env)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_claude_code_wrapper.py
+++ b/tests/test_claude_code_wrapper.py
@@ -193,6 +193,16 @@ class TestResolveClaudeBin:
 # ---------------------------------------------------------------------------
 
 class TestSummarize:
+    @pytest.fixture(autouse=True)
+    def _stub_claude_bin(self, tmp_path_factory: pytest.TempPathFactory, monkeypatch: pytest.MonkeyPatch) -> None:
+        # `summarize()` resolves the claude binary before invoking subprocess.run.
+        # CI runners don't have claude installed, so point HYACINE_CLAUDE_BIN at a
+        # stub — the mocked subprocess.run never actually executes it.
+        stub = tmp_path_factory.mktemp("claude-stub") / "claude"
+        stub.write_text("#!/bin/sh\nexit 0\n")
+        stub.chmod(0o755)
+        monkeypatch.setenv("HYACINE_CLAUDE_BIN", str(stub))
+
     def test_parses_result_field_from_list(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """Production path: `claude -p --output-format json` emits a list of events."""
         prompt_file = tmp_path / "prompt.md"


### PR DESCRIPTION
## Why

Daily `hyacine-run.timer` started failing the moment PR #4 (the `briefing` → `hyacine` rename) cut the service over. Two issues stacked, both invisible until journald was inspected.

## Root causes

1. **`FileNotFoundError: 'claude'`** — `subprocess.run(["claude", …])` relies on the inherited PATH. systemd user units use a minimal default PATH that omits `~/.local/bin`, where the official Claude Code installer drops the CLI binary.

2. **`subprocess produced no stdout. stderr=''`** — once PATH was fixed, `claude` 2.1.114 (now a single ELF binary with embedded JIT) was killed by SIGTRAP after ~100 ms. `MemoryDenyWriteExecute=true` in the unit traps the runtime when it tries to mark JIT pages writable+executable. No diagnostics emitted before the trap.

## Fix

- `src/hyacine/ops/systemd/hyacine-run.service`
  - Pin `Environment=PATH=%h/.local/bin:/usr/local/bin:/usr/bin:/bin`.
  - Comment out `MemoryDenyWriteExecute=true` with rationale.
- `src/hyacine/llm/claude_code.py`
  - New `resolve_claude_bin()` helper: honours `HYACINE_CLAUDE_BIN` override, else `shutil.which("claude")` against an augmented PATH that always includes `~/.local/bin`. Raises a clear `ClaudeCodeError` with the searched PATH on miss.
  - `summarize()` resolves the absolute path once before invoking `subprocess.run`.
- `docs/troubleshooting.md` documents both failure modes.

## Test plan

- [x] `pytest -q` — 165 passed (5 new tests for `resolve_claude_bin`).
- [x] `ruff check` clean on touched files.
- [x] Reproduced the SIGTRAP under `systemd-run --user --property=MemoryDenyWriteExecute=true`; confirmed the trap goes away once MDWE is dropped.
- [x] `systemctl --user start hyacine-run.service` → `OK: sent=… emails=7`; today's missed morning report was backfilled to the configured inbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)