### PR TITLE
chore: scrub leftover "briefing" references after hyacine rename

### DIFF
--- a/src/hyacine/db.py
+++ b/src/hyacine/db.py
@@ -10,7 +10,6 @@ systemd-launched runs + the web process.
 """
 from __future__ import annotations
 
-import sqlite3
 from collections.abc import Iterator
 from contextlib import contextmanager
 from datetime import datetime
@@ -91,67 +90,8 @@ def get_engine(db_path: Path) -> Engine:
     return _engine
 
 
-def _migrate_legacy_file(db_path: Path) -> None:
-    """If legacy ./data/briefing.db exists and the target doesn't, move it.
-
-    Safe under concurrent startup (web + run service): if another process
-    renamed the file between our exists() check and our rename() call, we
-    swallow the error and let the other caller finish the migration.
-    """
-    if db_path.exists():
-        return
-    legacy = db_path.parent / "briefing.db"
-    if not legacy.exists():
-        return
-    try:
-        legacy.rename(db_path)
-    except (FileNotFoundError, OSError):
-        return
-    for suffix in ("-shm", "-wal"):
-        src = legacy.with_name(legacy.name + suffix)
-        dst = db_path.with_name(db_path.name + suffix)
-        try:
-            if src.exists():
-                src.rename(dst)
-        except (FileNotFoundError, OSError):
-            continue
-
-
-def _migrate_legacy_schema(db_path: Path) -> None:
-    """Rename briefing_runs→runs and briefing_markdown→markdown, in place.
-
-    ALTER TABLE rename is not guarded by the sqlite_master snapshot under
-    concurrent startup, so we catch OperationalError and treat "already
-    migrated" as a no-op.
-    """
-    if not db_path.exists():
-        return
-    with sqlite3.connect(db_path) as conn:
-        tables = {
-            r[0] for r in conn.execute(
-                "SELECT name FROM sqlite_master WHERE type='table'"
-            )
-        }
-        if "briefing_runs" in tables and "runs" not in tables:
-            try:
-                conn.execute("ALTER TABLE briefing_runs RENAME TO runs")
-            except sqlite3.OperationalError:
-                pass
-        cols = {
-            r[1] for r in conn.execute("PRAGMA table_info(runs)")
-        }
-        if cols and "briefing_markdown" in cols and "markdown" not in cols:
-            try:
-                conn.execute(
-                    "ALTER TABLE runs RENAME COLUMN briefing_markdown TO markdown"
-                )
-            except sqlite3.OperationalError:
-                pass
-        conn.commit()
-
-
 def init_db(db_path: Path) -> None:
-    """Create tables and set PRAGMAs. Idempotent; migrates legacy schema.
+    """Create tables and set PRAGMAs. Idempotent.
 
     Also tightens filesystem perms: the parent dir is chmod 0700 and the
     DB file (plus any WAL/SHM siblings) chmod 0600, so the local database
@@ -160,8 +100,6 @@ def init_db(db_path: Path) -> None:
     support POSIX modes.
     """
     db_path.parent.mkdir(parents=True, exist_ok=True)
-    _migrate_legacy_file(db_path)
-    _migrate_legacy_schema(db_path)
     engine = get_engine(db_path)
     Base.metadata.create_all(engine)
 

--- a/src/hyacine/web/templates/prompt_editor.html
+++ b/src/hyacine/web/templates/prompt_editor.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Briefing · Prompt{% endblock %}
+{% block title %}Hyacine · Prompt{% endblock %}
 {% block content %}
 <h1>System prompt</h1>
 {% if error %}<p style="color:#dc3545"><strong>Validation error:</strong> {{ error }}</p>{% endif %}

--- a/src/hyacine/web/templates/rules_editor.html
+++ b/src/hyacine/web/templates/rules_editor.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Briefing · Rules{% endblock %}
+{% block title %}Hyacine · Rules{% endblock %}
 {% block content %}
 <h1>Classification rules</h1>
 {% if error %}<p style="color:#dc3545"><strong>Validation error:</strong> {{ error }}</p>{% endif %}

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,7 +1,6 @@
 """DB schema smoke tests — verify init_db is idempotent and WAL is on."""
 from __future__ import annotations
 
-import sqlite3
 import stat
 import sys
 from pathlib import Path
@@ -31,47 +30,6 @@ def test_init_db_is_idempotent(tmp_path: Path) -> None:
     _reset_engine()
     db_mod.init_db(db_path)
     db_mod.init_db(db_path)  # must not raise
-
-
-def test_legacy_schema_migration_is_idempotent(tmp_path: Path) -> None:
-    """Second call (simulating a concurrent startup) must not raise."""
-    db_path = tmp_path / "legacy.db"
-    with sqlite3.connect(db_path) as conn:
-        conn.execute(
-            "CREATE TABLE briefing_runs (id INTEGER PRIMARY KEY, briefing_markdown TEXT)"
-        )
-        conn.commit()
-
-    db_mod._migrate_legacy_schema(db_path)
-
-    with sqlite3.connect(db_path) as conn:
-        tables = {
-            r[0] for r in conn.execute(
-                "SELECT name FROM sqlite_master WHERE type='table'"
-            )
-        }
-        cols = {r[1] for r in conn.execute("PRAGMA table_info(runs)")}
-    assert "runs" in tables
-    assert "briefing_runs" not in tables
-    assert "markdown" in cols
-    assert "briefing_markdown" not in cols
-
-    db_mod._migrate_legacy_schema(db_path)  # already migrated → no-op
-
-
-def test_legacy_file_migration_second_call_is_noop(tmp_path: Path) -> None:
-    """If the legacy file was already renamed, a second call must not raise."""
-    data_dir = tmp_path / "data"
-    data_dir.mkdir()
-    legacy = data_dir / "briefing.db"
-    legacy.write_bytes(b"")
-    target = data_dir / "hyacine.db"
-
-    db_mod._migrate_legacy_file(target)
-    assert target.exists()
-    assert not legacy.exists()
-
-    db_mod._migrate_legacy_file(target)  # both branches are no-ops now
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="POSIX mode bits only")

--- a/tests/test_graph_send.py
+++ b/tests/test_graph_send.py
@@ -31,7 +31,6 @@ def test_render_html_body_escapes_script_tag() -> None:
 
 def test_send_email_posts_expected_body() -> None:
     """send_email should POST correctly shaped JSON to /me/sendMail."""
-    # (renamed test: was test_send_briefing_email_posts_expected_body)
     from hyacine.graph.send import send_email
 
     captured_payload: dict = {}

--- a/tests/test_scrub_check.py
+++ b/tests/test_scrub_check.py
@@ -56,7 +56,7 @@ def test_clean_tree_exits_0(tmp_path: Path) -> None:
     """A repo with no personal strings should exit 0."""
     _git_init(tmp_path)
     _git_add_commit(tmp_path, {
-        "README.md": "# Generic briefing template\n\nNo personal info here.\n",
+        "README.md": "# Generic template\n\nNo personal info here.\n",
         "src/example.py": 'print("hello world")\n',
     })
     result = _run_scrub(tmp_path)
@@ -101,7 +101,7 @@ def test_allowlisted_omc_specs_ignored(tmp_path: Path) -> None:
     """Files under .omc/specs/ are allowlisted and should not trigger violations."""
     _git_init(tmp_path)
     _git_add_commit(tmp_path, {
-        ".omc/specs/deep-interview-briefing-generalize.md": (
+        ".omc/specs/deep-interview-generalize.md": (
             "Original author: lushuyu. NUS grad student.\n"
         ),
         "README.md": "# Generic template\n",


### PR DESCRIPTION
## Summary
- Fixed the two web templates whose `<title>` still said `Briefing · …` — now consistent with `Hyacine · Dashboard` / `Hyacine · Run N`.
- Deleted the legacy `briefing.db` → `hyacine.db` file-move and `briefing_runs` → `runs` / `briefing_markdown` → `markdown` schema migrations (and their tests). The rename landed in d7ef40f; the initial public release (ed641d5) was already under `hyacine`, so there is no pre-rename data in the wild to migrate.
- Removed a stale `# (renamed test: was test_send_briefing_email_posts_expected_body)` comment and two incidental "briefing" fixture strings in `test_scrub_check`.

Remaining `briefing` mentions in `prompts/hyacine.md.template` and `examples/alice/prompts/hyacine.md` are the name of the **output email feature** (`# 📬 Daily Briefing`), not the old project name — those stay.

## Test plan
- [x] `uv run ruff check src tests` → clean
- [x] `uv run pytest tests/ -q` → 163 passed
- [ ] Load `/prompt` and `/rules` in a browser and confirm the tab title reads `Hyacine · Prompt` / `Hyacine · Rules`

🤖 Generated with [Claude Code](https://claude.com/claude-code)