### PR TITLE
fix(desktop): sidecar fallback + usable auth path for claude-cli provider

### DIFF
--- a/desktop/src-tauri/src/sidecar.rs
+++ b/desktop/src-tauri/src/sidecar.rs
@@ -71,37 +71,62 @@ impl SidecarState {
         let env = build_sidecar_env();
 
         // Prefer the bundled sidecar binary; fall back to `python -m hyacine.ipc`
-        // during development so you don't need to build the sidecar to iterate.
+        // during development or on installers that ship without a Python runtime.
         //
-        // The error messages here need to be specific — CI-built installers
-        // ship without a bundled Python runtime (see the externalBin note in
-        // tauri.conf.json), so a user on a clean machine will hit the
-        // fallback path with no Python on PATH. Tell them exactly what we
-        // tried and how to fix it.
-        let sidecar = app.shell().sidecar("hyacine-ipc");
-        let (mut rx, child) = match sidecar {
-            Ok(cmd) => cmd.envs(env.clone()).spawn().map_err(|e| {
-                AppError::Sidecar(format!(
-                    "bundled sidecar `hyacine-ipc` failed to spawn: {e}"
-                ))
-            })?,
-            Err(_) => {
-                let python = which_python();
-                app.shell()
-                    .command(python)
-                    .args(["-m", "hyacine.ipc"])
-                    .envs(env)
-                    .spawn()
-                    .map_err(|e| {
-                        AppError::Sidecar(format!(
-                            "Python sidecar unavailable. Tried `{python} -m hyacine.ipc`: {e}. \
-                             The bundled installer ships without a Python runtime yet — \
-                             install Python 3.11+ and run `pip install hyacine` (or clone \
-                             the repo and `uv sync`) to use connectivity testing and \
-                             pipeline runs. The wizard picker still works offline."
-                        ))
-                    })?
-            }
+        // Tauri 2's `app.shell().sidecar(name)` ALWAYS returns `Ok(cmd)` — it
+        // constructs a Command pointing at `{resource_dir}/hyacine-ipc` without
+        // touching the disk. The actual existence check happens at `.spawn()`.
+        // The previous match shape (Ok => spawn()?, Err => fallback) therefore
+        // never reached the Python fallback on installer builds: the bundled
+        // path returned Ok(cmd), spawn() failed with OS error 2 ("file not
+        // found"), and the `?` bubbled up the bundled error — leaving users on
+        // a clean install staring at "bundled sidecar failed to spawn" with no
+        // Python attempt ever made.
+        //
+        // Fix (issue #10): on spawn failure cascade to the Python fallback.
+        // When both fail, surface a combined message that names both attempts.
+        let python = which_python();
+        let (mut rx, child) = match app.shell().sidecar("hyacine-ipc") {
+            Ok(cmd) => match cmd.envs(env.clone()).spawn() {
+                Ok(pair) => {
+                    tracing::info!("sidecar: spawned bundled `hyacine-ipc`");
+                    pair
+                }
+                Err(bundled_err) => {
+                    tracing::info!(
+                        "bundled `hyacine-ipc` spawn failed ({bundled_err}); \
+                         falling back to `{python} -m hyacine.ipc`"
+                    );
+                    app.shell()
+                        .command(python)
+                        .args(["-m", "hyacine.ipc"])
+                        .envs(env)
+                        .spawn()
+                        .map_err(|py_err| {
+                            AppError::Sidecar(format!(
+                                "Sidecar unavailable. Bundled `hyacine-ipc`: {bundled_err}. \
+                                 Python fallback `{python} -m hyacine.ipc`: {py_err}. \
+                                 Install Python 3.11+ with `pip install hyacine` (or clone \
+                                 the repo and `uv sync`) to enable connectivity testing and \
+                                 pipeline runs. The wizard picker still works offline."
+                            ))
+                        })?
+                }
+            },
+            Err(sidecar_err) => app
+                .shell()
+                .command(python)
+                .args(["-m", "hyacine.ipc"])
+                .envs(env)
+                .spawn()
+                .map_err(|py_err| {
+                    AppError::Sidecar(format!(
+                        "Sidecar unavailable. Bundled sidecar plugin: {sidecar_err}. \
+                         Python fallback `{python} -m hyacine.ipc`: {py_err}. \
+                         Install Python 3.11+ with `pip install hyacine` (or clone the \
+                         repo and `uv sync`)."
+                    ))
+                })?,
         };
 
         let app_for_reader = app.clone();

--- a/desktop/src-tauri/src/sidecar.rs
+++ b/desktop/src-tauri/src/sidecar.rs
@@ -71,7 +71,10 @@ impl SidecarState {
         let env = build_sidecar_env();
 
         // Prefer the bundled sidecar binary; fall back to `python -m hyacine.ipc`
-        // during development or on installers that ship without a Python runtime.
+        // during development or on installers that ship without the bundled
+        // sidecar binary. The fallback itself requires Python on PATH — when
+        // that's also missing, the combined error message at the bottom names
+        // both failed attempts and points at `pip install hyacine`.
         //
         // Tauri 2's `app.shell().sidecar(name)` ALWAYS returns `Ok(cmd)` — it
         // constructs a Command pointing at `{resource_dir}/hyacine-ipc` without

--- a/desktop/src/lib/i18n.ts
+++ b/desktop/src/lib/i18n.ts
@@ -110,8 +110,11 @@ const messages = {
     providerKeyLooksGood: 'Looks good —',
     providerCliHeader: 'Uses the',
     providerCliBody:
-      "Run the command below in your terminal to authenticate; Hyacine picks up the resulting token via the subprocess. No key is needed in this screen.",
+      "Two ways to authenticate. (a) If you've already run `claude login` on this machine, leave the field below empty — Hyacine calls the `claude` CLI and it reads your stored credentials automatically. (b) Otherwise run the command below to generate a long-lived token, then paste it into the field.",
     providerCliSetupCmd: 'claude setup-token',
+    providerCliPasteOptional: 'Long-lived token (optional)',
+    providerCliPasteHint:
+      "Leave empty if `claude login` is already done. Otherwise paste the `sk-ant-oat…` token printed by `claude setup-token`.",
     providerDocs: 'Docs',
     providerCategoryOfficial: 'Official',
     providerCategoryRelay: 'Anthropic-compatible relay',
@@ -323,8 +326,12 @@ const messages = {
     providerReplace: '更换',
     providerKeyLooksGood: '格式正确 —',
     providerCliHeader: '使用',
-    providerCliBody: '在终端里运行下面的命令完成登录；Hyacine 会通过子进程读取生成的 token。此步不需要输入密钥。',
+    providerCliBody:
+      '两种登录方式。(a) 如果你已经在本机跑过 `claude login`，下面的输入框留空即可 —— Hyacine 调用 `claude` CLI 时它会自动读取本地凭证。(b) 否则运行下面的命令生成一个长期 token，粘贴到下方的输入框。',
     providerCliSetupCmd: 'claude setup-token',
+    providerCliPasteOptional: '长期 token（可选）',
+    providerCliPasteHint:
+      '已经 `claude login` 过就留空。否则把 `claude setup-token` 打印出来的 `sk-ant-oat…` 粘贴进来。',
     providerDocs: '文档',
     providerCategoryOfficial: '官方',
     providerCategoryRelay: 'Anthropic 兼容中继',

--- a/desktop/src/routes/wizard/provider/+page.svelte
+++ b/desktop/src/routes/wizard/provider/+page.svelte
@@ -61,6 +61,11 @@
   const requiresKey = $derived(effectiveFormat !== 'anthropic_cli' && !isLocalProvider);
   const requiresBaseUrl = $derived(selectedId === 'custom');
 
+  // Covers "key is optional, but if entered it must be valid". Today this only
+  // fires on the anthropic_cli paste field — users who leave it blank rely on
+  // `claude login`; users who paste must paste something `isClaudeKey` accepts.
+  const keyEnteredButInvalid = $derived(key.trim() !== '' && !validity.ok);
+
   // Keychain slug for the secret. Preset providers use their own id;
   // custom endpoints share a single stable slug so the pipeline's
   // resolve() helper can always find the key.
@@ -127,6 +132,13 @@
     // the active provider's keychain slot at spawn time.
     const usingStored = existingForSlug && !key;
     if (!usingStored && requiresKey && !validity.ok) {
+      pushToast('error', `Invalid key: ${validity.reason}`);
+      return;
+    }
+    // CLI + local providers make the key optional, but if the user *did*
+    // type something it must be a valid claude key — otherwise the probe
+    // would go out with obvious junk. Block early.
+    if (keyEnteredButInvalid) {
       pushToast('error', `Invalid key: ${validity.reason}`);
       return;
     }
@@ -489,6 +501,7 @@
       class="btn-secondary"
       disabled={testing ||
         (requiresKey && !existingForSlug && !validity.ok) ||
+        keyEnteredButInvalid ||
         (requiresBaseUrl && !customBaseUrl)}
       onclick={runTest}
     >
@@ -519,7 +532,7 @@
   <div class="flex justify-end pt-2">
     <button
       class="btn-primary"
-      disabled={requiresKey && !existingForSlug && !validity.ok}
+      disabled={(requiresKey && !existingForSlug && !validity.ok) || keyEnteredButInvalid}
       onclick={next}
     >
       {$t('continue')}

--- a/desktop/src/routes/wizard/provider/+page.svelte
+++ b/desktop/src/routes/wizard/provider/+page.svelte
@@ -400,30 +400,87 @@
       </label>
     {/if}
   {:else if effectiveFormat === 'anthropic_cli'}
-    <div class="card flex items-start gap-3 p-4 text-sm">
-      <Sparkles size="16" class="mt-0.5 text-[rgb(var(--accent))]" />
-      <div class="space-y-1">
-        <div class="font-medium">
-          {$t('providerCliHeader')}
-          <code class="rounded bg-[rgb(var(--border)/0.4)] px-1.5 py-0.5 font-mono text-[11px]">claude</code>
-          CLI
+    {#if existingForSlug}
+      <div class="card flex items-center gap-3 p-4">
+        <Lock size="18" class="text-[rgb(var(--accent))]" />
+        <div class="flex-1">
+          <div class="text-sm font-medium">{$t('providerKeyStored')}</div>
+          <div class="text-xs text-[rgb(var(--fg-muted))]">{$t('providerKeyStoredNote')} {slug}</div>
         </div>
-        <p class="text-[rgb(var(--fg-muted))]">{$t('providerCliBody')}</p>
-        <p class="text-[rgb(var(--fg-muted))]">
-          <code class="rounded bg-[rgb(var(--border)/0.4)] px-1.5 py-0.5 font-mono text-[11px]">{$t('providerCliSetupCmd')}</code>
-        </p>
-        {#if selectedPreset?.docs_url}
-          <a
-            href={selectedPreset.docs_url}
-            target="_blank"
-            rel="noopener"
-            class="inline-flex items-center gap-1 text-xs text-[rgb(var(--accent))] hover:underline"
-          >
-            {$t('providerDocs')} <ExternalLink size="10" />
-          </a>
-        {/if}
+        <button class="btn-ghost !text-xs" onclick={clearStoredKey}>{$t('providerReplace')}</button>
       </div>
-    </div>
+    {:else}
+      <div class="card space-y-3 p-4 text-sm">
+        <div class="flex items-start gap-3">
+          <Sparkles size="16" class="mt-0.5 flex-shrink-0 text-[rgb(var(--accent))]" />
+          <div class="flex-1 space-y-1">
+            <div class="font-medium">
+              {$t('providerCliHeader')}
+              <code class="rounded bg-[rgb(var(--border)/0.4)] px-1.5 py-0.5 font-mono text-[11px]">claude</code>
+              CLI
+            </div>
+            <p class="text-[rgb(var(--fg-muted))]">{$t('providerCliBody')}</p>
+            <p class="text-[rgb(var(--fg-muted))]">
+              <code class="rounded bg-[rgb(var(--border)/0.4)] px-1.5 py-0.5 font-mono text-[11px]">{$t('providerCliSetupCmd')}</code>
+            </p>
+            {#if selectedPreset?.docs_url}
+              <a
+                href={selectedPreset.docs_url}
+                target="_blank"
+                rel="noopener"
+                class="inline-flex items-center gap-1 text-xs text-[rgb(var(--accent))] hover:underline"
+              >
+                {$t('providerDocs')} <ExternalLink size="10" />
+              </a>
+            {/if}
+          </div>
+        </div>
+
+        <!-- Optional paste field. Empty = rely on `claude login` creds. -->
+        <label class="block space-y-1.5 pt-1">
+          <span class="block text-xs font-semibold text-[rgb(var(--fg-muted))]">
+            {$t('providerCliPasteOptional')}
+          </span>
+          <div class="relative">
+            {#if showKey}
+              <input
+                class="input pr-20 font-mono text-xs"
+                type="text"
+                bind:value={key}
+                autocomplete="off"
+                spellcheck="false"
+                placeholder="sk-ant-oat01-…"
+              />
+            {:else}
+              <input
+                class="input pr-20 font-mono text-xs"
+                type="password"
+                bind:value={key}
+                autocomplete="off"
+                spellcheck="false"
+                placeholder="sk-ant-oat01-…"
+              />
+            {/if}
+            <button
+              type="button"
+              class="absolute inset-y-0 right-2 my-auto h-7 rounded px-2 text-[rgb(var(--fg-muted))] hover:text-[rgb(var(--fg))]"
+              onclick={toggleShow}
+              aria-label={showKey ? 'Hide key' : 'Show key'}
+            >
+              {#if showKey}<EyeOff size="14" />{:else}<Eye size="14" />{/if}
+            </button>
+          </div>
+          <p class="text-[11px] text-[rgb(var(--fg-muted))]">{$t('providerCliPasteHint')}</p>
+          {#if key && !validity.ok}
+            <p class="text-xs text-red-500">{validity.reason}</p>
+          {:else if key && validity.ok}
+            <p class="text-xs text-[rgb(var(--fg-muted))]">
+              {$t('providerKeyLooksGood')} {maskKey(key)}
+            </p>
+          {/if}
+        </label>
+      </div>
+    {/if}
   {/if}
 
   <!-- Test row -->

--- a/src/hyacine/ipc/handlers/pipeline_h.py
+++ b/src/hyacine/ipc/handlers/pipeline_h.py
@@ -68,16 +68,14 @@ def _inject_claude_code_oauth() -> None:
 def _claude_token_missing() -> str | None:
     """Return a human-readable reason if pipeline execution can't proceed.
 
-    ``hyacine.llm.claude_code.build_env`` raises if
-    ``CLAUDE_CODE_OAUTH_TOKEN`` is absent. Catching that upstream gives a
-    much clearer message than the raw exception traceback the webview would
-    otherwise see in ``result.error``.
+    Historically this returned an error whenever ``CLAUDE_CODE_OAUTH_TOKEN``
+    was absent — but that blocked ``claude login`` users, for whom the CLI
+    reads credentials from its own store. With :func:`build_env` no longer
+    raising on a missing token (issue #10), we let ``claude -p`` attempt its
+    own auth and surface whatever error comes back. Returning ``None``
+    unconditionally preserves the signature for callers; the only real
+    blockers (claude binary missing) show up further down the pipeline.
     """
-    if not os.environ.get("CLAUDE_CODE_OAUTH_TOKEN"):
-        return (
-            "CLAUDE_CODE_OAUTH_TOKEN is not set. Re-run the Claude key step "
-            "or export the token in the sidecar environment before retrying."
-        )
     return None
 
 
@@ -94,6 +92,10 @@ def dry_run(
     started = time.time()
     _inject_claude_code_oauth()
 
+    # Previously we gated on CLAUDE_CODE_OAUTH_TOKEN here; since issue #10
+    # relaxed build_env to let `claude` self-auth from its own credential
+    # store, we just call through and surface whatever error the pipeline
+    # (or `claude -p`) emits. The helper returns None unconditionally now.
     if (missing := _claude_token_missing()) is not None:
         for stage in _STAGES:
             _emit_stage(emit, stage, "fail")
@@ -148,6 +150,10 @@ def run(
     started = time.time()
     _inject_claude_code_oauth()
 
+    # Previously we gated on CLAUDE_CODE_OAUTH_TOKEN here; since issue #10
+    # relaxed build_env to let `claude` self-auth from its own credential
+    # store, we just call through and surface whatever error the pipeline
+    # (or `claude -p`) emits. The helper returns None unconditionally now.
     if (missing := _claude_token_missing()) is not None:
         for stage in _STAGES:
             _emit_stage(emit, stage, "fail")

--- a/src/hyacine/ipc/handlers/pipeline_h.py
+++ b/src/hyacine/ipc/handlers/pipeline_h.py
@@ -49,34 +49,20 @@ def _silence_stdout() -> Any:
 
 
 def _inject_claude_code_oauth() -> None:
-    """Populate ``CLAUDE_CODE_OAUTH_TOKEN`` from the env if not already set.
+    """Populate ``CLAUDE_CODE_OAUTH_TOKEN`` from a sidecar-side alias if unset.
 
-    The Rust parent writes the token into the environment it hands us, but if
-    an end user is running the sidecar on its own (or in tests) the env var
-    might be missing; we accept ``HYACINE_CLAUDE_CODE_OAUTH_TOKEN`` as a
-    fallback. Callers must still validate presence themselves via
-    :func:`_claude_token_missing` — we don't raise here because a few
-    handlers (history, dry-run renders from cache) don't require the token.
+    The Rust parent normally writes the token into our env directly, but when
+    the sidecar is launched standalone (tests, dev shell, CI) it may only see
+    ``HYACINE_CLAUDE_CODE_OAUTH_TOKEN``. Forward it to the canonical var so
+    ``claude -p`` reads it transparently. No-op when the var is missing on
+    both sides — ``claude`` will then fall back to ``claude login`` creds
+    (issue #10).
     """
     if os.environ.get("CLAUDE_CODE_OAUTH_TOKEN"):
         return
     from_env = os.environ.get("HYACINE_CLAUDE_CODE_OAUTH_TOKEN", "")
     if from_env:
         os.environ["CLAUDE_CODE_OAUTH_TOKEN"] = from_env
-
-
-def _claude_token_missing() -> str | None:
-    """Return a human-readable reason if pipeline execution can't proceed.
-
-    Historically this returned an error whenever ``CLAUDE_CODE_OAUTH_TOKEN``
-    was absent — but that blocked ``claude login`` users, for whom the CLI
-    reads credentials from its own store. With :func:`build_env` no longer
-    raising on a missing token (issue #10), we let ``claude -p`` attempt its
-    own auth and surface whatever error comes back. Returning ``None``
-    unconditionally preserves the signature for callers; the only real
-    blockers (claude binary missing) show up further down the pipeline.
-    """
-    return None
 
 
 def dry_run(
@@ -91,19 +77,6 @@ def dry_run(
     """
     started = time.time()
     _inject_claude_code_oauth()
-
-    # Previously we gated on CLAUDE_CODE_OAUTH_TOKEN here; since issue #10
-    # relaxed build_env to let `claude` self-auth from its own credential
-    # store, we just call through and surface whatever error the pipeline
-    # (or `claude -p`) emits. The helper returns None unconditionally now.
-    if (missing := _claude_token_missing()) is not None:
-        for stage in _STAGES:
-            _emit_stage(emit, stage, "fail")
-        return {
-            "ok": False,
-            "error": missing,
-            "duration_ms": int((time.time() - started) * 1000),
-        }
 
     try:
         from hyacine.pipeline.run import run_pipeline  # noqa: PLC0415
@@ -149,19 +122,6 @@ def run(
     """Real pipeline run — fetch + summarise + deliver."""
     started = time.time()
     _inject_claude_code_oauth()
-
-    # Previously we gated on CLAUDE_CODE_OAUTH_TOKEN here; since issue #10
-    # relaxed build_env to let `claude` self-auth from its own credential
-    # store, we just call through and surface whatever error the pipeline
-    # (or `claude -p`) emits. The helper returns None unconditionally now.
-    if (missing := _claude_token_missing()) is not None:
-        for stage in _STAGES:
-            _emit_stage(emit, stage, "fail")
-        return {
-            "ok": False,
-            "error": missing,
-            "duration_ms": int((time.time() - started) * 1000),
-        }
 
     try:
         from hyacine.pipeline.run import run_pipeline  # noqa: PLC0415

--- a/src/hyacine/ipc/handlers/providers_h.py
+++ b/src/hyacine/ipc/handlers/providers_h.py
@@ -145,9 +145,15 @@ def test(  # noqa: C901 — mirrors providers.api_format branches; keeping a sin
 def _probe_anthropic_cli(*, api_key: str, model: str) -> dict[str, Any]:
     """Invoke ``claude -p "ping"`` with the given OAuth token.
 
-    Returns early with ``status == "skipped"`` when the ``claude`` binary
-    can't be found on PATH, since there's no meaningful probe we can run
-    locally in that case.
+    ``CLAUDE_CODE_OAUTH_TOKEN`` is preferred but not required: when the user
+    hasn't pasted a long-lived token yet, ``claude`` reads the credentials
+    written by ``claude login`` (``~/.claude/`` or platform keychain). Either
+    path is a legitimate "configured" state, so we let the CLI resolve auth
+    and surface whatever error comes back if neither source has creds —
+    rather than pre-failing with a confusing "skipped" verdict.
+
+    Genuine blockers (the ``claude`` binary itself being absent) still fail
+    loud; that's what the :func:`resolve_claude_bin` branch below catches.
     """
     from hyacine.llm.claude_code import resolve_claude_bin  # noqa: PLC0415
 
@@ -157,13 +163,6 @@ def _probe_anthropic_cli(*, api_key: str, model: str) -> dict[str, Any]:
         env["CLAUDE_CODE_OAUTH_TOKEN"] = api_key.strip()
     env.pop("ANTHROPIC_API_KEY", None)
     env.pop("ANTHROPIC_AUTH_TOKEN", None)
-    if "CLAUDE_CODE_OAUTH_TOKEN" not in env:
-        return {
-            "kind": "providers.test",
-            "status": "skipped",
-            "latency_ms": 0,
-            "detail": "no OAuth token",
-        }
     try:
         bin_path = resolve_claude_bin(env)
     except Exception as e:  # noqa: BLE001

--- a/src/hyacine/ipc/handlers/providers_h.py
+++ b/src/hyacine/ipc/handlers/providers_h.py
@@ -143,13 +143,14 @@ def test(  # noqa: C901 — mirrors providers.api_format branches; keeping a sin
 
 
 def _probe_anthropic_cli(*, api_key: str, model: str) -> dict[str, Any]:
-    """Invoke ``claude -p "ping"`` with the given OAuth token.
+    """Invoke ``claude -p "ping"`` using an optional OAuth token or existing CLI credentials.
 
-    ``CLAUDE_CODE_OAUTH_TOKEN`` is preferred but not required: when the user
-    hasn't pasted a long-lived token yet, ``claude`` reads the credentials
-    written by ``claude login`` (``~/.claude/`` or platform keychain). Either
-    path is a legitimate "configured" state, so we let the CLI resolve auth
-    and surface whatever error comes back if neither source has creds —
+    The ``api_key`` parameter is optional. When non-empty we export it as
+    ``CLAUDE_CODE_OAUTH_TOKEN`` for the subprocess; when empty, ``claude``
+    falls back to its own credential store (populated by ``claude login``
+    at ``~/.claude/`` or the platform keychain). Either path is a
+    legitimate "configured" state, so we let the CLI resolve auth and
+    surface whatever error comes back if neither source has creds —
     rather than pre-failing with a confusing "skipped" verdict.
 
     Genuine blockers (the ``claude`` binary itself being absent) still fail

--- a/src/hyacine/llm/claude_code.py
+++ b/src/hyacine/llm/claude_code.py
@@ -1,9 +1,10 @@
 """Subprocess wrapper for `claude -p` headless invocation.
 
 Critical environment rules (see task brief §1):
-  - CLAUDE_CODE_OAUTH_TOKEN must be present.
   - ANTHROPIC_API_KEY and ANTHROPIC_AUTH_TOKEN must be UNSET — otherwise they
     silently override OAuth and bill to the Console account.
+  - CLAUDE_CODE_OAUTH_TOKEN is preferred but *optional*: when absent, `claude`
+    falls back to its own credential store (populated by `claude login`).
   - Parse stdout JSON `result` field. Do NOT trust exit code (known bug).
 """
 from __future__ import annotations
@@ -20,12 +21,21 @@ class ClaudeCodeError(RuntimeError):
 
 
 def build_env(base_env: dict[str, str]) -> dict[str, str]:
-    """Return a copy of base_env with OAuth kept and API-key vars scrubbed."""
-    if "CLAUDE_CODE_OAUTH_TOKEN" not in base_env:
-        raise ClaudeCodeError(
-            "CLAUDE_CODE_OAUTH_TOKEN is not set in the environment. "
-            "Set it before invoking the claude subprocess."
-        )
+    """Return a copy of base_env with OAuth kept and API-key vars scrubbed.
+
+    ``CLAUDE_CODE_OAUTH_TOKEN`` is *not required* here — ``claude setup-token``
+    only prints a token to stdout (doesn't persist it anywhere), while
+    ``claude login`` writes credentials to ``~/.claude/`` or the OS keychain
+    that subsequent ``claude -p`` invocations read automatically. Hard-raising
+    when the env var is missing would block users who authenticated via
+    ``claude login``. If neither source of credentials exists, ``claude -p``
+    will surface its own ``Not authenticated`` error — that's the right layer
+    to handle the failure.
+
+    The API-key scrubbing is unconditional: those vars override OAuth and
+    would silently bill to the Console account instead of using the user's
+    Claude Code subscription.
+    """
     env = base_env.copy()
     env.pop("ANTHROPIC_API_KEY", None)
     env.pop("ANTHROPIC_AUTH_TOKEN", None)

--- a/tests/test_claude_code_wrapper.py
+++ b/tests/test_claude_code_wrapper.py
@@ -43,13 +43,22 @@ class TestBuildEnv:
         assert result["HOME"] == "/home/user"
         assert result["USER"] == "bob"
 
-    def test_raises_without_oauth_token(self) -> None:
+    def test_no_raise_without_oauth_token(self) -> None:
+        # build_env intentionally does NOT require CLAUDE_CODE_OAUTH_TOKEN —
+        # `claude login` users have their creds in ~/.claude/ or the OS
+        # keychain, and the `claude` CLI reads those automatically when no
+        # env var is set. Issue #10 softened this path; the API-key scrub
+        # is what stays unconditional.
         base = {
             "ANTHROPIC_API_KEY": "key",
+            "ANTHROPIC_AUTH_TOKEN": "also-key",
             "PATH": "/usr/bin",
         }
-        with pytest.raises(ClaudeCodeError, match="CLAUDE_CODE_OAUTH_TOKEN"):
-            build_env(base)
+        result = build_env(base)
+        assert "ANTHROPIC_API_KEY" not in result
+        assert "ANTHROPIC_AUTH_TOKEN" not in result
+        assert "CLAUDE_CODE_OAUTH_TOKEN" not in result
+        assert result["PATH"] == "/usr/bin"
 
     def test_does_not_mutate_base(self) -> None:
         base = {


### PR DESCRIPTION
Closes #10.

## Summary
- **Sidecar fallback**: Tauri 2's \`app.shell().sidecar(name)\` always returns \`Ok(cmd)\` — the existence check happens at \`.spawn()\`, not at plugin-resolution time. The old \`match sidecar { Ok(cmd) => cmd.spawn()?, Err(_) => python_fallback }\` therefore never reached the Python fallback on installer builds (which ship no bundled \`hyacine-ipc\` today, per d1df368). Now the spawn failure cascades to \`python -m hyacine.ipc\`; if *both* fail, the error message names both attempts.
- **claude-cli auth**: the wizard claimed \"Hyacine 会通过子进程读取生成的 token\", but \`claude setup-token\` just prints a token to stdout — it doesn't persist anywhere. With no paste input exposed for the CLI preset and the Python side hard-requiring \`CLAUDE_CODE_OAUTH_TOKEN\` in env, the only working path was exporting the var before launching the app. Now users have two real options: (a) leave the paste field empty if they've already run \`claude login\` — \`claude -p\` will read its own stored credentials — or (b) paste the long-lived token printed by \`claude setup-token\`, which gets written to the keychain like any other provider.

## Files touched
| File | Change |
|---|---|
| \`desktop/src-tauri/src/sidecar.rs\` | Spawn-failure cascades to Python fallback; combined error names both attempts |
| \`src/hyacine/llm/claude_code.py\` | \`build_env\` no longer raises when \`CLAUDE_CODE_OAUTH_TOKEN\` is missing; API-key scrub stays unconditional |
| \`src/hyacine/ipc/handlers/providers_h.py\` | \`_probe_anthropic_cli\` drops the \`skipped\`/\`no OAuth token\` short-circuit |
| \`src/hyacine/ipc/handlers/pipeline_h.py\` | \`_claude_token_missing\` returns \`None\` unconditionally, deferring to \`claude\` itself |
| \`desktop/src/routes/wizard/provider/+page.svelte\` | CLI preset now shows an optional paste field + \"Key stored / Replace\" card |
| \`desktop/src/lib/i18n.ts\` | en + zh-CN copy rewritten to describe both auth paths truthfully |
| \`tests/test_claude_code_wrapper.py\` | \`test_raises_without_oauth_token\` → \`test_no_raise_without_oauth_token\` to match the new contract |

## Verification
- \`pytest\` → **178 passed**
- \`npm run check\` → **0 errors, 0 warnings** (1827 files)
- \`npm run build\` → clean bundle (7.23s)
- \`ruff check\` on changed Python files → clean
- Rust build verified via CI (no local cargo toolchain on this dev box)

## Test plan
- [ ] Build installer (CI artifact), run on a clean VM **without** Python 3.11+ → error message now explicitly names both bundled and Python fallback.
- [ ] Build installer, install Python 3.11+ + \`pip install hyacine\` → app reaches dashboard, connectivity panel loads provider catalogue.
- [ ] In wizard, pick Claude (CLI), **don't** paste a token, have \`claude login\` done beforehand → Test connection reaches Anthropic successfully, dry run succeeds.
- [ ] In wizard, pick Claude (CLI), paste the \`sk-ant-oat…\` from \`claude setup-token\` → key lands in keychain, Test connection and dry run both succeed.
- [ ] In wizard, pick Claude (CLI) on a clean machine with neither \`claude login\` nor a pasted token → \`claude -p\` surfaces its own \"Not authenticated\" error instead of the generic \"CLAUDE_CODE_OAUTH_TOKEN is not set\".

🤖 Generated with [Claude Code](https://claude.com/claude-code)