### PR TITLE
fix(sidecar): accept provider config keys + stop excluding h11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,3 +283,107 @@ jobs:
           path: ${{ matrix.artifact-glob }}
           if-no-files-found: error
           retention-days: 14
+
+  # ──────────────────────────────────────────────────────────────────────
+  # Pre-release publish. Takes the installers the desktop matrix just
+  # produced and ships them as a GitHub Release marked `prerelease: true`.
+  #
+  # Tag selection:
+  # - refs/tags/v*        → use the tag verbatim; this is how a real
+  #                          release cut happens (`git tag v1.2.3 && git push`).
+  # - refs/heads/main     → rolling `nightly` release; each main push
+  #                          replaces the prior one so users always grab
+  #                          "latest built from main".
+  # - any other ref       → skip (PRs, feature branches).
+  #
+  # The release is always prerelease=true so the latest-tag promotion on
+  # GitHub's UI is a deliberate, human action — never an accident of a
+  # nightly push.
+  # ──────────────────────────────────────────────────────────────────────
+  prerelease:
+    name: Publish pre-release
+    needs: [python, desktop]
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
+    runs-on: ubuntu-latest
+    permissions:
+      # softprops/action-gh-release needs write to the Contents API for
+      # release + tag creation. No other scopes required.
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          # Full history so release notes could cite prior tags later
+          # (not used today, but the extra 2s is worth the option).
+          fetch-depth: 0
+
+      - name: Download installer artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          # Flatten every matrix artifact into one directory — each one
+          # already includes the target triple in its filename, so there
+          # are no collisions. Release assets don't support nested dirs.
+          merge-multiple: true
+          pattern: hyacine-*
+
+      - name: List downloaded artifacts
+        run: ls -la dist/ && find dist -type f | head -40
+
+      - name: Compute release metadata
+        id: meta
+        shell: bash
+        run: |
+          set -euo pipefail
+          short_sha="${GITHUB_SHA:0:7}"
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            tag="${GITHUB_REF#refs/tags/}"
+            title="Hyacine ${tag}"
+            rolling="false"
+          else
+            tag="nightly"
+            title="Nightly (main @ ${short_sha})"
+            rolling="true"
+          fi
+          {
+            echo "tag=${tag}"
+            echo "title=${title}"
+            echo "rolling=${rolling}"
+            echo "short_sha=${short_sha}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Clear previous rolling nightly
+        # Only for the rolling case: delete the existing `nightly` release
+        # (and its tag) so the new one points at this commit and the asset
+        # list doesn't accumulate stale uploads from prior builds.
+        if: steps.meta.outputs.rolling == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if gh release view nightly --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release delete nightly --repo "$GITHUB_REPOSITORY" --yes --cleanup-tag
+          else
+            echo "No prior nightly release; nothing to clear."
+          fi
+
+      - name: Publish pre-release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.meta.outputs.tag }}
+          name: ${{ steps.meta.outputs.title }}
+          prerelease: true
+          # Never mark a pre-release as "Latest" on the repo homepage —
+          # that bit should only flip when a human promotes a real tag.
+          make_latest: false
+          target_commitish: ${{ github.sha }}
+          files: dist/**
+          fail_on_unmatched_files: true
+          body: |
+            Automated pre-release from CI.
+
+            - Commit: `${{ github.sha }}`
+            - Run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            - Branch / tag: `${{ github.ref }}`
+
+            Installers are **unsigned** — see the desktop README for the one-time
+            SmartScreen / Gatekeeper bypass instructions.

--- a/desktop/sidecar/hyacine-ipc.spec
+++ b/desktop/sidecar/hyacine-ipc.spec
@@ -36,10 +36,13 @@ a = Analysis(
         "starlette",
         "uvicorn",
         "uvicorn.workers",
-        "h11",
         "httptools",
         "websockets",
-        "anyio._backends._trio",
+        # NOTE: `h11` is *kept* on purpose. It's an HTTP/1.1 parser used by
+        # uvicorn (which we drop) AND by httpcore / httpx (which we keep for
+        # every non-CLI provider call). Excluding it broke the
+        # anthropic_http and openai_chat probes with
+        # `No module named 'h11'` at first request. See issue #16.
         # Test / dev tooling that pyproject pulls transitively.
         "pytest",
         "mypy",

--- a/src/hyacine/ipc/handlers/config_h.py
+++ b/src/hyacine/ipc/handlers/config_h.py
@@ -25,6 +25,13 @@ _SAFE_KEYS: set[str] = {
     "language",
     "identity",
     "priorities",
+    # Provider selection — the wizard's /wizard/provider/ step writes these
+    # three to persist preset vs. custom-endpoint choice. Leaving them off
+    # the allowlist made every provider pick fail with the misleading
+    # "unknown config key: llm_api_format" error.
+    "llm_provider",
+    "llm_base_url",
+    "llm_api_format",
 }
 
 
@@ -41,6 +48,9 @@ def read_config() -> dict[str, Any]:
         "llm_model": cfg.llm_model,
         "run_time": cfg.run_time,
         "language": cfg.language,
+        "llm_provider": cfg.llm_provider,
+        "llm_base_url": cfg.llm_base_url,
+        "llm_api_format": cfg.llm_api_format,
         "identity": raw.get("identity", {"name": "", "role": "", "blurb": ""}),
         "priorities": raw.get("priorities", []),
     }

--- a/tests/test_config_handler.py
+++ b/tests/test_config_handler.py
@@ -24,10 +24,29 @@ from hyacine.ipc.protocol import INVALID_PARAMS, RpcError
 
 @pytest.fixture
 def tmp_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
-    """Point HYACINE_REPO_ROOT at an empty tmpdir so each test gets a fresh
-    config.yaml without touching the repo or the user's real config."""
+    """Point every HYACINE_* path override at a fresh tmpdir so tests can
+    never accidentally write to the developer's real config.
+
+    Setting ``HYACINE_REPO_ROOT`` alone is *not* enough: ``Settings`` also
+    honors per-path overrides like ``HYACINE_CONFIG_PATH`` — either
+    exported in the shell or loaded from the repo ``.env`` — and any of
+    those would beat the repo-root fallback. We drop them all first, then
+    pin ``HYACINE_CONFIG_PATH`` explicitly so there is zero ambiguity
+    about which file ``write_config()`` touches.
+    """
     (tmp_path / "config").mkdir()
+    for leak in (
+        "HYACINE_CONFIG_PATH",
+        "HYACINE_RULES_PATH",
+        "HYACINE_PROMPT_PATH",
+        "HYACINE_DB_PATH",
+        "HYACINE_AUTH_DIR",
+        "HYACINE_LOG_DIR",
+        "HYACINE_AUTH_RECORD_PATH",
+    ):
+        monkeypatch.delenv(leak, raising=False)
     monkeypatch.setenv("HYACINE_REPO_ROOT", str(tmp_path))
+    monkeypatch.setenv("HYACINE_CONFIG_PATH", str(tmp_path / "config" / "config.yaml"))
     return tmp_path
 
 

--- a/tests/test_config_handler.py
+++ b/tests/test_config_handler.py
@@ -1,0 +1,67 @@
+"""Regression tests for the config IPC handler.
+
+The wizard's /wizard/provider/ step persists its choice by calling
+``config.write`` with ``llm_provider`` / ``llm_base_url`` /
+``llm_api_format``. An earlier version of ``_SAFE_KEYS`` omitted those
+three, so every provider pick failed with
+
+    unknown config key: llm_api_format
+
+Mostly boring allowlist book-keeping, but the failure is silent enough
+(users just can't advance past the provider step) that it's worth a
+test pinning the happy path.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hyacine.config import YamlConfig
+from hyacine.ipc.handlers import config_h
+from hyacine.ipc.protocol import INVALID_PARAMS, RpcError
+
+
+@pytest.fixture
+def tmp_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point HYACINE_REPO_ROOT at an empty tmpdir so each test gets a fresh
+    config.yaml without touching the repo or the user's real config."""
+    (tmp_path / "config").mkdir()
+    monkeypatch.setenv("HYACINE_REPO_ROOT", str(tmp_path))
+    return tmp_path
+
+
+def test_write_config_accepts_provider_fields(tmp_repo: Path) -> None:
+    res = config_h.write_config(
+        llm_provider="openai",
+        llm_base_url="https://api.openai.com/v1",
+        llm_api_format="openai_chat",
+        llm_model="gpt-4o-mini",
+    )
+    assert res["ok"] is True
+
+    got = config_h.read_config()
+    assert got["llm_provider"] == "openai"
+    assert got["llm_base_url"] == "https://api.openai.com/v1"
+    assert got["llm_api_format"] == "openai_chat"
+    assert got["llm_model"] == "gpt-4o-mini"
+
+
+def test_write_config_still_rejects_unknown_key(tmp_repo: Path) -> None:
+    with pytest.raises(RpcError) as e:
+        config_h.write_config(nonsense_field="oops")
+    assert e.value.code == INVALID_PARAMS
+    assert "unknown config key" in str(e.value)
+
+
+def test_safe_keys_covers_every_provider_field() -> None:
+    """Catches the case where a future refactor adds a new `llm_*` field
+    to YamlConfig but forgets to whitelist it — the wizard would silently
+    break again."""
+    yaml_fields = set(YamlConfig.model_fields)
+    provider_fields = {f for f in yaml_fields if f.startswith("llm_")}
+    missing = provider_fields - config_h._SAFE_KEYS
+    assert not missing, (
+        f"YamlConfig has {missing} that the IPC allowlist rejects — "
+        f"either add them to _SAFE_KEYS or explicitly carve them out here"
+    )


### PR DESCRIPTION
## Summary

Two unrelated-looking errors that turned out to block the same user flow (finishing the provider step of the wizard with anything other than Claude Code OAuth), plus a scope-adjacent CI improvement so merging this lands a testable pre-release.

- Add `llm_provider`, `llm_base_url`, `llm_api_format` to `_SAFE_KEYS` in the IPC config handler + return them from `read_config()`. The wizard already writes those three; the allowlist just hadn't been updated.
- Remove `h11` from the PyInstaller excludes list. It was tagged as "uvicorn weight", but `httpcore`/`httpx` (every non-CLI provider path) also needs it, and the bundled sidecar was crashing every HTTP request with `No module named 'h11'`.
- Add a regression test that pins `_SAFE_KEYS` against every `llm_*` field on `YamlConfig`, so this exact class of bug fails CI next time someone adds a field.
- Harden the `tmp_repo` fixture per Copilot review: scrub every `HYACINE_*_PATH` override and pin `HYACINE_CONFIG_PATH` explicitly so the tests can't write to a developer's real config.yaml.
- Add a `prerelease` CI job. After `python` + `desktop` succeed on a push to `main` or a `v*` tag, it downloads the matrix installers and publishes them as a pre-release on GitHub. `main` → rolling `nightly` tag (old release/tag deleted first so asset list stays clean); `v*` → that tag verbatim. `prerelease: true` + `make_latest: false` so the homepage "Latest" pointer is always a deliberate human action. PR runs skip the job via the `if` guard.

Closes #16.

## Test plan

- [x] `uv run pytest -q` → 181 passed (3 new).
- [ ] Desktop build via CI: `desktop` job produces installers without `ImportError: No module named 'h11'` in the `Smoke-test sidecar` step.
- [ ] On merging into `main`, the `prerelease` job creates a `nightly` release visible at `Releases` on the repo, carrying every matrix installer as an asset.
- [ ] In the wizard, picking any preset (OAuth, Console, DeepSeek, OpenAI, Ollama, or Custom) commits past `/wizard/provider/` without a toast about `unknown config key`.
- [ ] `/app/settings` reloads a config containing `llm_provider` / `llm_base_url` / `llm_api_format` without dropping those three fields on the floor.