### PR TITLE
ci: tolerate partial desktop matrix + version-stamp nightly tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -357,40 +357,37 @@ jobs:
 
       - name: Compute release metadata
         id: meta
+        # Mirrors the "Stamp build version" step in the desktop job so the
+        # release tag matches the version embedded inside the installer.
+        #
+        # - refs/tags/v*   → use the tag verbatim, e.g. `v1.2.3`.
+        # - refs/heads/main → derive `major.minor.<run_number>` from
+        #                     tauri.conf.json + GITHUB_RUN_NUMBER, then tag
+        #                     `nightly-<version>`. GITHUB_RUN_NUMBER climbs
+        #                     with every workflow run so each nightly gets a
+        #                     unique tag — no need to delete the prior tag,
+        #                     no race against the upload step.
         shell: bash
         run: |
           set -euo pipefail
           short_sha="${GITHUB_SHA:0:7}"
           if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
-            tag="${GITHUB_REF#refs/tags/}"
+            version="${GITHUB_REF#refs/tags/v}"
+            tag="v${version}"
             title="Hyacine ${tag}"
-            rolling="false"
           else
-            tag="nightly"
-            title="Nightly (main @ ${short_sha})"
-            rolling="true"
+            major=$(jq -r .version desktop/src-tauri/tauri.conf.json | cut -d. -f1)
+            minor=$(jq -r .version desktop/src-tauri/tauri.conf.json | cut -d. -f2)
+            version="${major}.${minor}.${GITHUB_RUN_NUMBER:-0}"
+            tag="nightly-${version}"
+            title="Nightly ${version} (main @ ${short_sha})"
           fi
           {
             echo "tag=${tag}"
             echo "title=${title}"
-            echo "rolling=${rolling}"
+            echo "version=${version}"
             echo "short_sha=${short_sha}"
           } >> "$GITHUB_OUTPUT"
-
-      - name: Clear previous rolling nightly
-        # Only for the rolling case: delete the existing `nightly` release
-        # (and its tag) so the new one points at this commit and the asset
-        # list doesn't accumulate stale uploads from prior builds.
-        if: steps.meta.outputs.rolling == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          if gh release view nightly --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-            gh release delete nightly --repo "$GITHUB_REPOSITORY" --yes --cleanup-tag
-          else
-            echo "No prior nightly release; nothing to clear."
-          fi
 
       - name: Publish pre-release
         uses: softprops/action-gh-release@v2
@@ -407,6 +404,7 @@ jobs:
           body: |
             Automated pre-release from CI.
 
+            - Version: `${{ steps.meta.outputs.version }}`
             - Commit: `${{ github.sha }}`
             - Run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
             - Branch / tag: `${{ github.ref }}`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,8 +285,16 @@ jobs:
           retention-days: 14
 
   # ──────────────────────────────────────────────────────────────────────
-  # Pre-release publish. Takes the installers the desktop matrix just
-  # produced and ships them as a GitHub Release marked `prerelease: true`.
+  # Pre-release publish. Takes whatever installers the desktop matrix
+  # managed to produce and ships them as a GitHub Release marked
+  # `prerelease: true`.
+  #
+  # Partial matrix is OK. `always()` + `python.result == 'success'` lets
+  # us publish when e.g. one platform's tauri-bundler has a transient
+  # flake (the macOS bundle_dmg.sh is historically prone to this) — users
+  # on the four green platforms get their installers now, and the flaky
+  # one can be rerun at leisure. If ZERO cells succeed we bail loudly so
+  # the job doesn't quietly publish an empty release.
   #
   # Tag selection:
   # - refs/tags/v*        → use the tag verbatim; this is how a real
@@ -303,7 +311,15 @@ jobs:
   prerelease:
     name: Publish pre-release
     needs: [python, desktop]
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
+    # `always()` bypasses the default "skip if any needed job failed"
+    # behaviour so a single flaky matrix cell doesn't block the nightly
+    # entirely. We still require Python tests to be green (non-negotiable)
+    # and gate on the push ref so PRs never publish.
+    if: >-
+      always()
+      && needs.python.result == 'success'
+      && github.event_name == 'push'
+      && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
     runs-on: ubuntu-latest
     permissions:
       # softprops/action-gh-release needs write to the Contents API for
@@ -328,6 +344,16 @@ jobs:
 
       - name: List downloaded artifacts
         run: ls -la dist/ && find dist -type f | head -40
+
+      - name: Abort if no installers were produced
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -z "$(find dist -mindepth 1 -type f 2>/dev/null | head -1)" ]]; then
+            echo "::error::No installer artifacts present — every desktop matrix cell failed. Aborting release."
+            exit 1
+          fi
+          echo "Found $(find dist -type f | wc -l) installer file(s) to publish."
 
       - name: Compute release metadata
         id: meta


### PR DESCRIPTION
## Summary

Two small adjustments to the `prerelease` job added in #17:

- **Tolerate partial matrix.** The first post-merge run was swallowed by a flaky macOS bundler; `needs: [python, desktop]` skipped the publish job because one cell failed. Now gated on `always() && needs.python.result == 'success'` so Python stays non-negotiable but a flaky platform no longer blocks the other four. Extra "abort if zero installers" step keeps the failure loud in the pathological case.

- **Version-stamp nightly tags.** Replace the rolling `nightly` tag with `nightly-<major>.<minor>.<run_number>` using the same derivation as the desktop job's `Stamp build version` step. Each workflow run gets a unique tag, so:
  - no delete-recreate dance (previous code had to delete the old release + tag first),
  - installer filenames on disk match the release tag they came from,
  - rollback to any prior nightly is a direct click on the Releases page.

  `v*` tag pushes keep their verbatim behaviour — real releases still cut as `vX.Y.Z`.

## Test plan

- [ ] Merging this triggers a CI run on main.
- [ ] The `prerelease` job runs even if the macOS `bundle_dmg.sh` flake recurs.
- [ ] A new release appears named like `nightly-1.0.<run_number>`, with the Releases page sorting it above the old rolling `nightly` entry.
- [ ] Later pushes produce fresh `nightly-1.0.<run+1>` releases without clobbering the previous one.