### PR TITLE
release: v1.2.0 — modern email shell + security hardening + i18n + dry-run parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,66 @@ All notable changes to Hyacine are listed here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] — 2026-04-26
+
+Email pipeline cut: the daily digest gets HyacineAI's design language
+(pansy header, hero serif title, color-bar section titles, three-segment
+footer with provider/model) across Apple Mail, Gmail web, iOS Mail, and
+Outlook 2016+. Plus security + correctness hardening on the renderer
+(escape config-derived strings before interpolating into HTML, harden
+the anchor regex against quoted `>`, drop dead exception-swallowing
+fallback in the run-detail view), end-to-end language plumbing
+(`<html lang>` reflects the configured language with a sensible
+fallback), a new public `hyacine.i18n` module, and dry-run preview
+parity with real sends.
+
+### Added
+
+- **Modern HTML email shell.** New `hyacine.graph.email_render` module
+  wraps the LLM markdown in HyacineAI's design language — header carries
+  date + localised weekday, section titles take their color bar from the
+  prompt template's emoji prefixes (🔴/🟡/🟢/⚪), footer surfaces the
+  active provider/model. All inline styles, no external assets.
+- **`hyacine.i18n` module.** New public `weekday_label(dt, language)`
+  helper supporting `en`, `zh-CN`, `zh-TW`, `ja` (English fallback for
+  unknown codes); previously a private helper inside `pipeline.run`.
+- **`render_html_fragment` API.** Same sanitisation + design language
+  as `render_html_body` but skips the `<html>` shell so the FastAPI
+  run-detail view embeds without nesting documents inside a `<div>`.
+- **Per-language `<html lang>` attribute.** `render_modern_email_html`
+  accepts a `language` argument and maps YAML config codes to BCP-47
+  tags so screen readers / client heuristics see the language the
+  digest was actually written in.
+
+### Fixed
+
+- **Run-detail view nested a full HTML document inside a `<div>`.**
+  Switched the markdown renderer to `render_html_fragment` so the
+  embedded body is now a clean fragment.
+- **Dry-run wizard preview footer drifted from the real send.** Preview
+  now reads `language` and `timezone` from the YAML config and computes
+  `now` in that zone, going through the same `weekday_label` helper as
+  the pipeline. Run-time values (date / time / weekday) inherently
+  shift between preview and run; everything else now matches.
+- **Anchor styling regex terminated early on `>` inside quoted attrs.**
+  Pattern now treats quoted strings atomically so e.g. `title="a>b"`
+  no longer breaks link styling.
+- **Dead `NotImplementedError` fallback in `web/routes/runs.py`.**
+  `render_html_fragment` never raises it; the catch was masking
+  unrelated runtime errors. Restricted to module-import-only.
+- **Unknown language codes leaked into `<html lang>`.** `_bcp47` now
+  defaults to `en` when the config language isn't one we localise,
+  matching the docstring contract.
+
+### Changed
+
+- Pipeline forwards `model`, local `date` / `weekday` / `time`, and
+  `language` into `send_email` so the modern footer reflects the
+  per-run config.
+- Version bumped to 1.2.0 across `pyproject.toml`, `desktop/package.json`,
+  `desktop/package-lock.json`, `desktop/src-tauri/tauri.conf.json`,
+  `desktop/src-tauri/Cargo.toml`, and `desktop/src-tauri/Cargo.lock`.
+
 ## [1.1.0] — 2026-04-23
 
 Release-engineering cut that makes the desktop wizard end-to-end usable,

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hyacine-desktop",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hyacine-desktop",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.1.1",
         "@tauri-apps/plugin-dialog": "^2.0.1",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyacine-desktop",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -1574,7 +1574,7 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hyacine-desktop"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "keyring",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyacine-desktop"
-version = "1.1.0"
+version = "1.2.0"
 description = "Hyacine — desktop shell for the Outlook + Claude daily briefing"
 authors = ["Hyacine"]
 edition = "2021"

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2.0.0",
   "productName": "Hyacine",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "identifier": "com.hyacine.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hyacine"
-version = "1.1.0"
+version = "1.2.0"
 description = "Hyacine — daily Outlook + Claude report delivered to your inbox"
 requires-python = ">=3.11,<3.13"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -504,7 +504,7 @@ http2 = [
 
 [[package]]
 name = "hyacine"
-version = "1.1.0"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "azure-identity" },


### PR DESCRIPTION
## Summary

Cuts **v1.2.0**. Bumps `pyproject.toml`, `uv.lock`, `desktop/package.json`, `desktop/package-lock.json`, `desktop/src-tauri/{tauri.conf.json, Cargo.toml, Cargo.lock}` from `1.1.0` → `1.2.0`, and prepends a `[1.2.0]` entry to `CHANGELOG.md`.

The cut wraps PR #22 plus the rolling correctness/security work that landed alongside it:

- **Modern HTML email shell** — pansy header (date + localised weekday), hero serif title, color-bar section titles driven by the prompt template's emoji prefixes, three-segment footer carrying the active provider/model. Inline styles only; lands cleanly in Apple Mail, Gmail web, iOS Mail, Outlook 2016+.
- **Security hardening** on the renderer — `model` / `date` / `weekday` / `generated_at` are HTML-escaped before interpolation; anchor styling regex now treats quoted attributes atomically (so `title="a>b"` no longer terminates the match early); `<li>` / `<ul>` styling switched to opening-tag-only injection (the prior non-greedy `.*?` corrupted nested lists).
- **End-to-end language plumbing** — pipeline forwards `model`, local date / weekday / time, and `language` into `send_email`; `<html lang>` mapped from YAML codes to BCP-47 with `en` as the fallback for unknown codes.
- **New `hyacine.i18n` module** — public `weekday_label(dt, language)` (was a private helper inside `pipeline.run`); cross-module callers no longer reach into private API.
- **Dry-run preview parity** — wizard preview reads `language`/`timezone` from YAML config, computes `now` in that zone, and goes through the same render path as the real send.
- **Run-detail view** uses `render_html_fragment` so the body is no longer a full `<html>` document nested inside a `<div>`.
- **Dead `NotImplementedError` fallback** in `web/routes/runs.py` was masking unrelated runtime errors; restricted to module-import only.

## Release flow

1. Merge this PR (squash or merge — either is fine; the tag follows the merge commit).
2. After the merge lands on `main`, tag `v1.2.0` on the merge commit and push the tag — CI's stable-release channel takes it from there (`refs/tags/vX.Y.Z` → promoted to "Latest").

## Test plan

- [x] `uv run pytest -q` → 199 passed
- [x] All four version files parse (json + toml)
- [x] Manual end-to-end resend of run #20 via the new shell verified the rendered HTML reaches the inbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)